### PR TITLE
[packaging] Only BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/cups.spec
+++ b/rpm/cups.spec
@@ -89,11 +89,9 @@ Patch100: cups-lspp.patch
 
 
 BuildRequires: pam-devel
-BuildRequires: pkgconfig
 BuildRequires: pkgconfig(gnutls)
 BuildRequires: libacl-devel
 BuildRequires: pkgconfig(libusb-1.0)
-BuildRequires: systemd
 BuildRequires: pkgconfig(libsystemd)
 BuildRequires: pkgconfig(dbus-1)
 


### PR DESCRIPTION
We already include systemd as BuildRequires lets drop it so the right systemd
variant gets installed into the builder.