### PR TITLE
Remove openssl-devel requirement from devel package

### DIFF
--- a/rpm/cups.spec
+++ b/rpm/cups.spec
@@ -107,7 +107,6 @@ Requires: /usr/sbin/alternatives
 Summary: Common Unix Printing System - development environment
 License: LGPLv2
 Requires: %{name}-libs%{?_isa} = %{version}-%{release}
-Requires: openssl-devel
 Requires: zlib-devel
 Provides: cupsddk-devel
 


### PR DESCRIPTION
Simple requirement causes conflict on OBS between openssl and
openssl1.1 devel packages. A requirement for pkgconfig(openssl) is
added automatically during build anyway so a manual requirement is
not needed.
